### PR TITLE
Small fixes for extractor

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -11,7 +11,7 @@ impl Graph {
     pub fn load(reverse: bool) -> Graph {
         let graph_file = if reverse {
             println!("Loading reverse graph ..");
-                crate::GRAPH_REVERSE
+            crate::GRAPH_REVERSE
         } else {
             println!("Loading graph ..");
             crate::GRAPH


### PR DESCRIPTION
Just two small things I've noticed while trying out this project:
- The first commit fixes the path handling of the extractor. Previously it tried to open the `.sql.gz` in the current directory instead of in the `data` directory.
- The second commit skips lines with invalid UTF-8 data as I've encountered a panic there while extracting `enwiki-20191001-pagelinks.sql.gz`. (Haven't investigated why exactly there's invalid UTF-8...) The diff is pretty unclean but it basically just wraps the whole block in an `if let Ok(line) = line { ... } else { ... }`.